### PR TITLE
znormalize in one iteration instead of two

### DIFF
--- a/matrixprofile/utils.py
+++ b/matrixprofile/utils.py
@@ -19,13 +19,13 @@ def zNormalize(ts):
     ts: Time series to be normalized
     """
 
-    ts -= np.mean(ts)
+    mu = np.mean(ts)
     std = np.std(ts)
 
     if std == 0:
         raise ValueError("The Standard Deviation cannot be zero")
-    else:
-        ts /= std
+    
+    ts = (ts - mu) / std
 
     return ts
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18449075/51492847-c8950080-1d78-11e9-803e-df42f1a62e68.png)

Reducing the compute time on this function should save a lot of time in the long run on larger time series.