### PR TITLE
Parallelize stamp

### DIFF
--- a/matrixprofile/distanceProfile.py
+++ b/matrixprofile/distanceProfile.py
@@ -71,6 +71,24 @@ def massDistanceProfile(tsA,idx,m,tsB = None):
     #Both the distance profile and corresponding matrix profile index (which should just have the current index)
     return (distanceProfile,np.full(n-m+1,idx,dtype=float))
 
+def mass_distance_profile_parallel(indices, tsA=None, tsB=None, m=None):
+    """
+    Computes distance profiles for the given indices either via self join or similarity search.
+    
+    Parameters
+    ----------
+    indices: Array of indices to compute distance profile for.
+    tsA: Time series containing the query for which to calculate the distance profile.
+    tsB: Time series to compare the query against. Note that, for the time being, only tsB = tsA is allowed
+    m: Length of query.
+    """
+    distance_profiles = []
+    
+    for index in indices:
+        distance_profiles.append(massDistanceProfile(tsA, index, m, tsB=tsB))
+    
+    return distance_profiles
+
 
 def STOMPDistanceProfile(tsA,idx,m,tsB,dot_first,dp,mean,std):
     """

--- a/matrixprofile/matrixProfile.py
+++ b/matrixprofile/matrixProfile.py
@@ -66,7 +66,18 @@ def _matrixProfile(tsA,m,orderClass,distanceProfileFunction,tsB=None):
 
     return (mp,mpIndex)
 
-def _stamp_parallel(tsA, m, tsB=None, sampling=0.2, n_threads=None):
+def _stamp_parallel(tsA, m, tsB=None, sampling=0.2, n_threads=-1):
+    """
+    Computes distance profiles in parallel using all CPU cores by default.
+    
+    Parameters
+    ----------
+    tsA: Time series containing the queries for which to calculate the Matrix Profile.
+    m: Length of subsequence to compare.
+    tsB: Time series to compare the query against. Note that, if no value is provided, tsB = tsA by default.
+    sampling: The percentage of all possible distance profiles to sample for the final Matrix Profile. 0 to 1
+    n_threads: Number of threads to use in parallel mode. Defaults to using all CPU cores.
+    """
     if n_threads is -1:
         n_threads = multiprocessing.cpu_count()
     

--- a/matrixprofile/matrixProfile.py
+++ b/matrixprofile/matrixProfile.py
@@ -11,6 +11,9 @@ from . import distanceProfile
 from . import order
 from .utils import mass, movmeanstd
 import numpy as np
+import multiprocessing
+from functools import partial
+import math
 
 def _self_join_or_not_preprocess(tsA, tsB, m):
     """
@@ -63,6 +66,43 @@ def _matrixProfile(tsA,m,orderClass,distanceProfileFunction,tsB=None):
 
     return (mp,mpIndex)
 
+def _stamp_parallel(tsA, m, tsB=None, sampling=0.2, n_threads=None):
+    if n_threads is -1:
+        n_threads = multiprocessing.cpu_count()
+    
+    n = len(tsA)
+    mp, mpIndex = _self_join_or_not_preprocess(tsA, tsB, m)
+
+    # determine sampling size
+    sample_size = math.ceil((n - m + 1) * sampling)
+    
+    # generate indices to sample and split based on n_threads
+    indices = np.arange(n - m + 1)
+    
+    if sampling < 1 and sampling > 0:
+        indices = np.random.choice(indices, size=sample_size, replace=False)
+
+    indices = np.array_split(indices, n_threads)
+    
+    # create pool of workers and compute
+    with multiprocessing.Pool(processes=n_threads) as pool:
+        func = partial(distanceProfile.mass_distance_profile_parallel, tsA=tsA, tsB=tsB, m=m)
+        results = pool.map(func, indices)
+    
+    # The overall matrix profile is the element-wise minimum of each sub-profile, and each element of the overall
+    # matrix profile index is the time series position of the corresponding sub-profile.
+    for result in results:
+        for dp, querySegmentsID in result:
+            #Check which of the indices have found a new minimum
+            idsToUpdate = dp < mp
+
+            #Update the Matrix Profile Index to indicate that the current index is the minimum location for the aforementioned indices
+            mpIndex[idsToUpdate] = querySegmentsID[idsToUpdate]
+
+            #Update the matrix profile to include the new minimum values (where appropriate)
+            mp = np.minimum(mp, dp)
+
+    return (mp, mpIndex)
 
 def _matrixProfile_sampling(tsA,m,orderClass,distanceProfileFunction,tsB=None,sampling=0.2):
     order = orderClass(len(tsA)-m+1)
@@ -184,7 +224,7 @@ def stmp(tsA,m,tsB=None):
     """
     return _matrixProfile(tsA,m,order.linearOrder,distanceProfile.massDistanceProfile,tsB)
 
-def stamp(tsA,m,tsB=None,sampling=0.2):
+def stamp(tsA,m,tsB=None,sampling=0.2, n_threads=None):
     """
     Calculate the Matrix Profile using the more efficient MASS calculation. Distance profiles are computed in a random order.
 
@@ -194,8 +234,12 @@ def stamp(tsA,m,tsB=None,sampling=0.2):
     m: Length of subsequence to compare.
     tsB: Time series to compare the query against. Note that, if no value is provided, tsB = tsA by default.
     sampling: The percentage of all possible distance profiles to sample for the final Matrix Profile.
+    n_threads: Number of threads to use in parallel mode. Defaults to single threaded mode. Set to -1 to use all threads.
     """
-    return _matrixProfile_sampling(tsA,m,order.randomOrder,distanceProfile.massDistanceProfile,tsB,sampling=sampling)
+    if n_threads is None:
+        return _matrixProfile_sampling(tsA,m,order.randomOrder,distanceProfile.massDistanceProfile,tsB,sampling=sampling)
+    
+    return _stamp_parallel(tsA, m, tsB=tsB, sampling=sampling, n_threads=n_threads)
 
 def stomp(tsA,m,tsB=None):
     """

--- a/matrixprofile/matrixProfile.py
+++ b/matrixprofile/matrixProfile.py
@@ -66,7 +66,7 @@ def _matrixProfile(tsA,m,orderClass,distanceProfileFunction,tsB=None):
 
     return (mp,mpIndex)
 
-def _stamp_parallel(tsA, m, tsB=None, sampling=0.2, n_threads=-1):
+def _stamp_parallel(tsA, m, tsB=None, sampling=0.2, n_threads=-1, random_state=None):
     """
     Computes distance profiles in parallel using all CPU cores by default.
     
@@ -77,6 +77,7 @@ def _stamp_parallel(tsA, m, tsB=None, sampling=0.2, n_threads=-1):
     tsB: Time series to compare the query against. Note that, if no value is provided, tsB = tsA by default.
     sampling: The percentage of all possible distance profiles to sample for the final Matrix Profile. 0 to 1
     n_threads: Number of threads to use in parallel mode. Defaults to using all CPU cores.
+    random_state: Set the random seed generator for reproducible results.
     """
     if n_threads is -1:
         n_threads = multiprocessing.cpu_count()
@@ -88,11 +89,11 @@ def _stamp_parallel(tsA, m, tsB=None, sampling=0.2, n_threads=-1):
     sample_size = math.ceil((n - m + 1) * sampling)
     
     # generate indices to sample and split based on n_threads
-    indices = np.arange(n - m + 1)
+    if random_state is not None:
+        np.random.seed(random_state)
     
-    if sampling < 1 and sampling > 0:
-        indices = np.random.choice(indices, size=sample_size, replace=False)
-
+    indices = np.arange(n - m + 1)
+    indices = np.random.choice(indices, size=sample_size, replace=False)
     indices = np.array_split(indices, n_threads)
     
     # create pool of workers and compute
@@ -115,8 +116,8 @@ def _stamp_parallel(tsA, m, tsB=None, sampling=0.2, n_threads=-1):
 
     return (mp, mpIndex)
 
-def _matrixProfile_sampling(tsA,m,orderClass,distanceProfileFunction,tsB=None,sampling=0.2):
-    order = orderClass(len(tsA)-m+1)
+def _matrixProfile_sampling(tsA,m,orderClass,distanceProfileFunction,tsB=None,sampling=0.2,random_state=None):
+    order = orderClass(len(tsA)-m+1, random_state=random_state)
     mp, mpIndex = _self_join_or_not_preprocess(tsA, tsB, m)
 
     idx=order.next()
@@ -235,7 +236,7 @@ def stmp(tsA,m,tsB=None):
     """
     return _matrixProfile(tsA,m,order.linearOrder,distanceProfile.massDistanceProfile,tsB)
 
-def stamp(tsA,m,tsB=None,sampling=0.2, n_threads=None):
+def stamp(tsA,m,tsB=None,sampling=0.2, n_threads=None, random_state=None):
     """
     Calculate the Matrix Profile using the more efficient MASS calculation. Distance profiles are computed in a random order.
 
@@ -246,14 +247,15 @@ def stamp(tsA,m,tsB=None,sampling=0.2, n_threads=None):
     tsB: Time series to compare the query against. Note that, if no value is provided, tsB = tsA by default.
     sampling: The percentage of all possible distance profiles to sample for the final Matrix Profile. 0 to 1
     n_threads: Number of threads to use in parallel mode. Defaults to single threaded mode. Set to -1 to use all threads.
+    random_state: Set the random seed generator for reproducible results.
     """
     if sampling > 1 or sampling < 0:
         raise ValueError('Sampling value must be a percentage in decimal format from 0 to 1.')
     
     if n_threads is None:
-        return _matrixProfile_sampling(tsA,m,order.randomOrder,distanceProfile.massDistanceProfile,tsB,sampling=sampling)
+        return _matrixProfile_sampling(tsA,m,order.randomOrder,distanceProfile.massDistanceProfile,tsB,sampling=sampling,random_state=random_state)
     
-    return _stamp_parallel(tsA, m, tsB=tsB, sampling=sampling, n_threads=n_threads)
+    return _stamp_parallel(tsA, m, tsB=tsB, sampling=sampling, n_threads=n_threads, random_state=random_state)
 
 def stomp(tsA,m,tsB=None):
     """

--- a/matrixprofile/matrixProfile.py
+++ b/matrixprofile/matrixProfile.py
@@ -233,9 +233,12 @@ def stamp(tsA,m,tsB=None,sampling=0.2, n_threads=None):
     tsA: Time series containing the queries for which to calculate the Matrix Profile.
     m: Length of subsequence to compare.
     tsB: Time series to compare the query against. Note that, if no value is provided, tsB = tsA by default.
-    sampling: The percentage of all possible distance profiles to sample for the final Matrix Profile.
+    sampling: The percentage of all possible distance profiles to sample for the final Matrix Profile. 0 to 1
     n_threads: Number of threads to use in parallel mode. Defaults to single threaded mode. Set to -1 to use all threads.
     """
+    if sampling > 1 or sampling < 0:
+        raise ValueError('Sampling value must be a percentage in decimal format from 0 to 1.')
+    
     if n_threads is None:
         return _matrixProfile_sampling(tsA,m,order.randomOrder,distanceProfile.massDistanceProfile,tsB,sampling=sampling)
     

--- a/matrixprofile/order.py
+++ b/matrixprofile/order.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 range = getattr(__builtins__, 'xrange', range)
 # end of py2 compatability boilerplate
 
-import random
+import numpy as np
 
 class Order:
     """
@@ -39,10 +39,15 @@ class randomOrder(Order):
     """
     An object that defines a random order in which the distance profiles are calculated for a given Matrix Profile
     """
-    def __init__(self,m):
+    def __init__(self,m, random_state=None):
         self.idx = -1
-        self.indices = list(range(m))
-        random.shuffle(self.indices)
+        self.indices = np.arange(m)
+        self.random_state = random_state
+        
+        if self.random_state is not None:
+            np.random.seed(self.random_state)
+        
+        np.random.shuffle(self.indices)
 
     def next(self):
         """

--- a/tests/test_matrixProfile.py
+++ b/tests/test_matrixProfile.py
@@ -168,3 +168,48 @@ class TestClass(object):
         with pytest.raises(ValueError) as excinfo:
             stamp(None,None,sampling=-1)
         assert 'Sampling value must be a percentage' in str(excinfo.value)
+        
+    def test_stamp_random_state_same_results_self_join(self):
+        random_state = 99
+        sampling = 0.30
+        a = np.array([0.0,1.0,1.0,0.0,0.0,1.0,1.0,0.0,0.0,1.0,1.0,0.0])
+        
+        r = stamp(a,4,None,sampling=sampling,random_state=random_state)
+        r2 = stamp(a,4,None,sampling=sampling,random_state=random_state)
+        
+        all_same = (r[0] == r2[0]).all() and (r[1] == r2[1]).all()
+        assert(all_same == True)
+        
+        
+    def test_stamp_random_state_same_results_dual_join(self):
+        random_state = 99
+        sampling = 0.30
+        a = np.array([0.0,1.0,1.0,0.0,0.0,1.0,1.0,0.0,0.0,1.0,1.0,0.0])
+        b = np.array([0.0,1.0,1.0,0.2,0.0,1.0,1.0,0.3,0.0,1.0,1.0,0.0])
+        
+        r = stamp(a,4,b,sampling=sampling,random_state=random_state)
+        r2 = stamp(a,4,b,sampling=sampling,random_state=random_state)
+        
+        all_same = (r[0] == r2[0]).all() and (r[1] == r2[1]).all()
+        assert(all_same == True)
+        
+    def test_stamp_with_parallel_version_random_state_set_self_join(self):
+        random_state = 99
+        sampling = 0.1
+        a = np.array([0.0,1.0,1.0,0.0,0.0,1.0,1.0,0.0,0.0,1.0,1.0,0.0])
+        r = stamp(a,4,None,sampling=sampling,random_state=random_state)
+        r2 = stamp(a,4,None,sampling=sampling,random_state=random_state)
+
+        all_same = (r[0] == r2[0]).all() and (r[1] == r2[1]).all()
+        assert(all_same == True)
+        
+    def test_stamp_with_parallel_version_random_state_set_dual_join(self):
+        random_state = 99
+        sampling = 0.1
+        a = np.array([0.0,1.0,1.0,0.0,0.0,1.0,1.0,2.0,0.0,1.1,1.0,0.0])
+        b = np.array([0.0,1.0,1.0,0.0,0.0,1.0,1.0,0.0,0.0,1.0,1.0,0.0])
+        r = stamp(a,4,b,sampling=sampling,random_state=random_state)
+        r2 = stamp(a,4,b,sampling=sampling,random_state=random_state)
+
+        all_same = (r[0] == r2[0]).all() and (r[1] == r2[1]).all()
+        assert(all_same == True)

--- a/tests/test_matrixProfile.py
+++ b/tests/test_matrixProfile.py
@@ -158,3 +158,13 @@ class TestClass(object):
         r = stomp(a,4)
 
         assert(r[1] == mpi_outcome).all()
+        
+    def test_stamp_sampling_over_one(self):
+        with pytest.raises(ValueError) as excinfo:
+            stamp(None,None,sampling=2)
+        assert 'Sampling value must be a percentage' in str(excinfo.value)
+        
+    def test_stamp_sampling_under_zero(self):
+        with pytest.raises(ValueError) as excinfo:
+            stamp(None,None,sampling=-1)
+        assert 'Sampling value must be a percentage' in str(excinfo.value)

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -60,3 +60,26 @@ class TestClass(object):
         outcome = np.array([0,1,2,3,4,5,6,7,8,9])
 
         assert(unique_vals == outcome).all()
+
+    def test_randomOrder_random_state_same_results(self):
+        random_state=99
+        order = randomOrder(10, random_state=random_state)
+        order2 = randomOrder(10, random_state=random_state)
+        
+        indices = []
+        t = order.next()
+        while t is not None:
+            indices.append(t)
+            t = order.next()
+            
+        indices2 = []
+        t2 = order2.next()
+        while t2 is not None:
+            indices2.append(t2)
+            t2 = order2.next()
+        
+        indices = np.array(indices)
+        indices2 = np.array(indices2)
+        
+        all_same = (indices == indices2).all()
+        assert(all_same == True)


### PR DESCRIPTION
Utilizes all core methods to make stamp algorithm parallel. If we can think of a clever way to update the 1-NN indices, it could be even faster.

Original pull request did not include documentation commit.